### PR TITLE
[JENKINS-25090] Durable task compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.554.3</version>
+        <version>1.609.1</version>
     </parent>
     <artifactId>mock-slave</artifactId>
     <version>1.7-SNAPSHOT</version>
@@ -27,7 +27,6 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.106</version>
                 <configuration>
                     <loggers>
                         <org.jenkinci.plugins.mock_slave>FINE</org.jenkinci.plugins.mock_slave>
@@ -53,7 +52,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>0.5</version>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
@@ -58,7 +58,7 @@ public final class MockCloud extends Cloud {
     private static final AtomicInteger counter = new AtomicInteger();
 
     static {
-        // Make things happen more quickly so that we can test it interactively.
+        // JENKINS-24752: make things happen more quickly so that we can test it interactively.
         NodeProvisioner.NodeProvisionerInvoker.INITIALDELAY = 1000;
         NodeProvisioner.NodeProvisionerInvoker.RECURRENCEPERIOD = 1000;
     }

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
@@ -25,7 +25,6 @@
 package org.jenkinci.plugins.mock_slave;
 
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
@@ -85,8 +84,8 @@ public final class MockCloud extends Cloud {
         while (excessWorkload > 0) {
             final int cnt = counter.incrementAndGet();
             r.add(new NodeProvisioner.PlannedNode("Mock Slave #" + cnt, Computer.threadPoolForRemoting.submit(new Callable<Node>() {
-                public Node call() throws Exception {
-                    return new MockCloudSlave(cnt, mode, numExecutors, labelString);
+                @Override public Node call() throws Exception {
+                    return new MockCloudSlave("mock-slave-" + cnt, mode, numExecutors, labelString);
                 }
             }), numExecutors));
             excessWorkload -= numExecutors;
@@ -105,8 +104,8 @@ public final class MockCloud extends Cloud {
 
     private static final class MockCloudSlave extends AbstractCloudSlave {
 
-        MockCloudSlave(int cnt, Node.Mode mode, int numExecutors, String labelString) throws FormException, IOException {
-            super("mock-slave-" + cnt, "Mock Slave", Util.createTempDir().getAbsolutePath(), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), numExecutors == 1 ? new OnceRetentionStrategy(1) : new CloudRetentionStrategy(1), Collections.<NodeProperty<?>>emptyList());
+        MockCloudSlave(String slaveName, Node.Mode mode, int numExecutors, String labelString) throws FormException, IOException {
+            super(slaveName, "Mock Slave", MockSlave.root(slaveName), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), numExecutors == 1 ? new OnceRetentionStrategy(1) : new CloudRetentionStrategy(1), Collections.<NodeProperty<?>>emptyList());
         }
 
         @Override public AbstractCloudComputer<?> createComputer() {

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
@@ -25,19 +25,25 @@
 package org.jenkinci.plugins.mock_slave;
 
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Slave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class MockSlave extends Slave {
 
     @DataBoundConstructor public MockSlave(String name, int numExecutors, Mode mode, String labelString, RetentionStrategy<?> retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws IOException, Descriptor.FormException {
-    	super(name, "", Util.createTempDir().getAbsolutePath(), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), retentionStrategy, nodeProperties);
+    	super(name, "", root(name), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), retentionStrategy, nodeProperties);
+    }
+
+    /** Provides a predictable {@code remoteFS} unique for a given slave name and Jenkins instance. */
+    static String root(String slaveName) {
+        return new File(new File(Jenkins.getInstance().getRootDir(), "mock-slaves"), slaveName).getAbsolutePath();
     }
     
     @Extension public static final class DescriptorImpl extends SlaveDescriptor {

--- a/src/test/java/org/jenkinci/plugins/mock_slave/MockSlaveLauncherTest.java
+++ b/src/test/java/org/jenkinci/plugins/mock_slave/MockSlaveLauncherTest.java
@@ -3,7 +3,6 @@ package org.jenkinci.plugins.mock_slave;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.ComputerListener;
 import hudson.slaves.DumbSlave;
@@ -11,6 +10,7 @@ import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import jenkins.security.MasterToSlaveCallable;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.Rule;
@@ -38,8 +38,8 @@ public class MockSlaveLauncherTest {
         latch.await();
         assertEquals(43, slave.getChannel().call(new TestCallable()).intValue());
     }
-    private static class TestCallable implements Callable<Integer,Error> {
-        public Integer call() throws Error {
+    private static class TestCallable extends MasterToSlaveCallable<Integer,Error> {
+        @Override public Integer call() throws Error {
             return 43;
         }
     }


### PR DESCRIPTION
[JENKINS-25090](https://issues.jenkins-ci.org/browse/JENKINS-25090)

- [X] use the same `remoteFS` after a restart
- [X] avoid killing subprocesses on a live slave during (safe) restart

With these changes, a workflow

```groovy
node('mock-cloud') {
    sh 'sleep 60'
}
```

will survive a Jenkins `/safeRestart`. It will also survive a `SIGTERM` sent to the Jenkins master (e.g., using `kill $PID`).

(Note that Ctrl-C from a Bourne shell will kill the `sleep` process because the shell sends `SIGTERM` to the whole process tree. Currently the only way to defend durable tasks running on a “local” slave against this is to put them in their own process tree, normally using an SSH launcher, though [JENKINS-25503](https://issues.jenkins-ci.org/browse/JENKINS-25503) would be the proper solution.)

With some more testing, the latter change could probably be applied also to `LocalLauncher` in core, from which `MockSlaveLauncher` was originally adapted, though again JENKINS-25503 might obviate that.

If merged and released, this plugin would provide a more attractive alternative to the hardcoded SSH slave definitions in https://github.com/jenkinsci/workflow-plugin/pull/163,  as well as other demos and automated tests that involve durable tasks and elastic clouds.

@reviewbybees