### PR TITLE
Allow agents to not be one-shot even when there is one executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.609.1</version>
+        <version>2.14</version>
+        <relativePath/>
     </parent>
     <artifactId>mock-slave</artifactId>
     <version>1.10-SNAPSHOT</version>
@@ -13,15 +14,19 @@
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/mock-slave-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/mock-slave-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/mock-slave-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+    <properties>
+        <jenkins.version>1.609.3</jenkins.version>
+        <java.level>6</java.level>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -39,13 +44,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>mock-slave</artifactId>
     <version>1.10-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <name>Mock Slave Plugin</name>
+    <name>Mock Agent Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Mock+Slave+Plugin</url>
     <licenses>
         <license>

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
@@ -80,14 +80,14 @@ public final class MockCloud extends Cloud {
         Collection<NodeProvisioner.PlannedNode> r = new ArrayList<NodeProvisioner.PlannedNode>();
         while (excessWorkload > 0) {
             final long cnt = ((DescriptorImpl) getDescriptor()).newNodeNumber();
-            r.add(new NodeProvisioner.PlannedNode("Mock Slave #" + cnt, Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+            r.add(new NodeProvisioner.PlannedNode("Mock Agent #" + cnt, Computer.threadPoolForRemoting.submit(new Callable<Node>() {
                 @Override public Node call() throws Exception {
                     return new MockCloudSlave("mock-slave-" + cnt, mode, numExecutors, labelString);
                 }
             }), numExecutors));
             excessWorkload -= numExecutors;
         }
-        LOGGER.log(Level.FINE, "planning to provision {0} slaves", r.size());
+        LOGGER.log(Level.FINE, "planning to provision {0} agents", r.size());
         return r;
     }
 
@@ -114,7 +114,7 @@ public final class MockCloud extends Cloud {
     private static final class MockCloudSlave extends AbstractCloudSlave {
 
         MockCloudSlave(String slaveName, Node.Mode mode, int numExecutors, String labelString) throws FormException, IOException {
-            super(slaveName, "Mock Slave", MockSlave.root(slaveName), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), numExecutors == 1 ? new OnceRetentionStrategy(1) : new CloudRetentionStrategy(1), Collections.<NodeProperty<?>>emptyList());
+            super(slaveName, "Mock Agent", MockSlave.root(slaveName), numExecutors, mode, labelString, new MockSlaveLauncher(0, 0), numExecutors == 1 ? new OnceRetentionStrategy(1) : new CloudRetentionStrategy(1), Collections.<NodeProperty<?>>emptyList());
         }
 
         @Override public AbstractCloudComputer<?> createComputer() {

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
@@ -43,13 +43,13 @@ public final class MockSlave extends Slave {
 
     /** Provides a predictable {@code remoteFS} unique for a given slave name and Jenkins instance. */
     static String root(String slaveName) {
-        return new File(new File(Jenkins.getInstance().getRootDir(), "mock-slaves"), slaveName).getAbsolutePath();
+        return new File(new File(Jenkins.getInstance().getRootDir(), "mock-agents"), slaveName).getAbsolutePath();
     }
     
     @Extension public static final class DescriptorImpl extends SlaveDescriptor {
 
         @Override public String getDisplayName() {
-            return "Mock Slave";
+            return "Mock Agent";
         }
 
     }

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockSlave.java
@@ -43,7 +43,7 @@ public final class MockSlave extends Slave {
 
     /** Provides a predictable {@code remoteFS} unique for a given slave name and Jenkins instance. */
     static String root(String slaveName) {
-        return new File(new File(Jenkins.getInstance().getRootDir(), "mock-agents"), slaveName).getAbsolutePath();
+        return new File(new File(Jenkins.getActiveInstance().getRootDir(), "mock-agents"), slaveName).getAbsolutePath();
     }
     
     @Extension public static final class DescriptorImpl extends SlaveDescriptor {

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockSlaveLauncher.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockSlaveLauncher.java
@@ -104,7 +104,7 @@ public class MockSlaveLauncher extends ComputerLauncher {
                 }
             }
         });
-        LOGGER.log(Level.INFO, "slave agent launched for {0}", computer.getDisplayName());
+        LOGGER.log(Level.INFO, "agent launched for {0}", computer.getDisplayName());
     }
 
     @IgnoreJRERequirement
@@ -119,7 +119,7 @@ public class MockSlaveLauncher extends ComputerLauncher {
     @Extension
     public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
         public String getDisplayName() {
-            return "Mock Slave Launcher";
+            return "Mock Agent Launcher";
         }
     }
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <div>
-  Launches a slave agent on the local machine to simulate a remote agent.
+  Launches an agent on the local machine to simulate a remote agent.
   Optionally simulates network latency problems.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   Launches an agent on the local machine to simulate a remote agent.
   Optionally simulates network latency problems.

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/MockCloudComputer/configure.jelly
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/MockCloudComputer/configure.jelly
@@ -25,10 +25,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
-    <l:layout title="Cloud Slave">
+    <l:layout title="Cloud Agent">
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
-            This slave is ephemeral, so there is nothing to configure.
+            This agent is ephemeral, so there is nothing to configure.
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/config.jelly
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/config.jelly
@@ -35,4 +35,7 @@ THE SOFTWARE.
     <f:entry field="labelString" title="Labels">
         <f:textbox/>
     </f:entry>
+    <f:entry field="oneShot" title="One-shot Agents">
+        <f:checkbox default="true"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-numExecutors.html
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-numExecutors.html
@@ -1,6 +1,3 @@
 <div>
     Number of executors to allot per mock agent.
-    If set to one, the agent automatically adopts a “one-shot” retention strategy:
-    it is killed immediately after the build finishes, and a new agent must be provisioned for any other build.
-    If greater than one, the agent will accept new builds, staying online for at least one minute after the last one finishes.
 </div>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-numExecutors.html
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-numExecutors.html
@@ -1,6 +1,6 @@
 <div>
-    Number of executors to allot per mock slave.
-    If set to one, the slave automatically adopts a “one-shot” retention strategy:
-    it is killed immediately after the build finishes, and a new slave must be provisioned for any other build.
-    If greater than one, the slave will accept new builds, staying online for at least one minute after the last one finishes.
+    Number of executors to allot per mock agent.
+    If set to one, the agent automatically adopts a “one-shot” retention strategy:
+    it is killed immediately after the build finishes, and a new agent must be provisioned for any other build.
+    If greater than one, the agent will accept new builds, staying online for at least one minute after the last one finishes.
 </div>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-oneShot.html
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-oneShot.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, the agent automatically adopts a “one-shot” retention strategy:
+    it is killed immediately after the build finishes, and a new agent must be provisioned for any other build.
+    Otherwise, the agent will accept new builds, staying online for at least one minute after the last one finishes.
+</div>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockSlave/newInstanceDetail.jelly
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockSlave/newInstanceDetail.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <div>
-    A slave using a new temporary directory for its filesystem root and running on localhost.
+    An agent using a new temporary directory for its filesystem root and running on localhost.
 </div>


### PR DESCRIPTION
Improved performance of https://github.com/jenkinsci/parallel-test-executor-plugin/pull/20, which does not require one-shot semantics and which just incurs the overhead of repeated class loading.

Also followed terminology change in core.

@reviewbybees