### PR TITLE
Testing JCasC export when there is a mock cloud agent connected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.0-rc3</version>
+            <version>1.1-rc496.a2e1e32ab2f8</version> <!-- TODO https://github.com/jenkinsci/configuration-as-code-plugin/pull/512 -->
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.1-rc496.a2e1e32ab2f8</version> <!-- TODO https://github.com/jenkinsci/configuration-as-code-plugin/pull/512 -->
+            <version>1.1-rc502.d9171d086fbb</version> <!-- TODO https://github.com/jenkinsci/configuration-as-code-plugin/pull/524 -->
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
@@ -162,6 +162,14 @@ public final class MockCloud extends Cloud {
             // need do nothing
         }
 
+        @Extension public static final class DescriptorImpl extends SlaveDescriptor {
+
+            @Override public boolean isInstantiable() {
+                return false;
+            }
+
+        }
+
     }
 
     private static final class MockCloudComputer extends AbstractCloudComputer<MockCloudSlave> {

--- a/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
@@ -58,6 +58,7 @@ public class ConfigAsCodeTest {
     }
 
     @Test public void export() throws Exception {
+        r.jenkins.setCrumbIssuer(null); // TestCrumbIssuer noise
         r.jenkins.setNumExecutors(0);
         r.jenkins.clouds.add(new MockCloud("mock"));
         FreeStyleProject p = r.createFreeStyleProject();

--- a/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
 
 public class ConfigAsCodeTest {
 
@@ -54,6 +55,17 @@ public class ConfigAsCodeTest {
         p.setAssignedLabel(null); // sets canRoam
         FreeStyleBuild b = r.buildAndAssertSuccess(p);
         assertNotEquals("", b.getBuiltOnStr());
+    }
+
+    @Test public void export() throws Exception {
+        r.jenkins.setNumExecutors(0);
+        r.jenkins.clouds.add(new MockCloud("mock"));
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.setAssignedLabel(null);
+        p.getBuildersList().add(new SleepBuilder(Long.MAX_VALUE));
+        FreeStyleBuild b = p.scheduleBuild2(0).waitForStart();
+        r.waitForMessage("Sleeping", b);
+        ConfigurationAsCode.get().export(System.out);
     }
 
 }


### PR DESCRIPTION
Integration test for https://github.com/jenkinsci/configuration-as-code-plugin/pull/512.

```yaml
# …
  disableRememberMe: false
  mode: NORMAL
  nodes: "FAILED TO EXPORT hudson.model.Hudson#nodes: \njava.lang.AssertionError:\
    \ class org.jenkinci.plugins.mock_slave.MockCloud$MockCloudSlave is missing its\
    \ descriptor\n\tat jenkins.model.Jenkins.getDescriptorOrDie(Jenkins.java:1538)\n\
    \tat hudson.model.Slave.getDescriptor(Slave.java:516)\n\tat hudson.model.Slave.getDescriptor(Slave.java:96)\n\
    \tat io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:153)\n\
    \tat io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:43)\n\
    \tat io.jenkins.plugins.casc.Attribute.describe(Attribute.java:183)\n\tat io.jenkins.plugins.casc.core.JenkinsConfigurator.describe(JenkinsConfigurator.java:70)\n\
    \tat io.jenkins.plugins.casc.core.JenkinsConfigurator.describe(JenkinsConfigurator.java:25)\n\
    \tat io.jenkins.plugins.casc.ConfigurationAsCode.export(ConfigurationAsCode.java:406)\n\
    \tat org.jenkinci.plugins.mock_slave.ConfigAsCodeTest.export(ConfigAsCodeTest.java:68)\n\
    \tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\
    \tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\
    \tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\
    \tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\
    \tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\
    \tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\
    \tat org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:548)\n\tat\
    \ org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)\n\
    \tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)\n\
    \tat java.util.concurrent.FutureTask.run(FutureTask.java:266)\n\tat java.lang.Thread.run(Thread.java:748)\n"
  numExecutors: 0
  primaryView:
# …
```

It is not unusual for managed classes like this to lack a `Descriptor` (`/computer/mock-agent-1/configure` displays a special message explaining that it cannot be configured), but without the upstream patch, the entire export fails. In fact from the web UI you get a 500 error.