### PR TITLE
[JENKINS-66742] Adapt to tables-to-divs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.26</version>
+        <version>4.27</version>
         <relativePath />
     </parent>
     <artifactId>mock-slave</artifactId>
@@ -25,7 +25,7 @@
     </scm>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <build>
@@ -62,8 +62,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>918.vae501d2cdc99</version>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>950.v396cb834de1e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockSlave/configure-entries.jelly
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockSlave/configure-entries.jelly
@@ -38,11 +38,7 @@ THE SOFTWARE.
                 <f:dropdownListBlock value="${d.clazz.name}" name="${d.displayName}" selected="${it.retentionStrategy.descriptor==d}" title="${d.displayName}">
                     <j:set var="descriptor" value="${d}"/>
                     <j:set var="instance" value="${it.retentionStrategy.descriptor==d ? it.retentionStrategy : null}"/>
-                    <tr>
-                        <td>
-                            <input type="hidden" name="stapler-class" value="${d.clazz.name}"/>
-                        </td>
-                    </tr>
+                    <f:class-entry descriptor="${d}"/>
                     <st:include from="${d}" page="${d.configPage}" optional="true"/>
                 </f:dropdownListBlock>
             </j:if>


### PR DESCRIPTION
[JENKINS-66742](https://issues.jenkins.io/browse/JENKINS-66742): this plugin was broken by https://github.com/jenkinsci/jenkins/pull/3895 apparently because it copied an idiom from `DumbSlave/configure-entries.jelly` prior to https://github.com/jenkinsci/jenkins/pull/1443.
