### PR TITLE
Update parent, fixing `ConfigAsCodeTest.export`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.62</version>
+        <version>4.65</version>
         <relativePath/>
     </parent>
     <artifactId>mock-slave</artifactId>

--- a/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinci/plugins/mock_slave/ConfigAsCodeTest.java
@@ -67,6 +67,8 @@ public class ConfigAsCodeTest {
         FreeStyleBuild b = p.scheduleBuild2(0).waitForStart();
         r.waitForMessage("Sleeping", b);
         ConfigurationAsCode.get().export(System.out);
+        b.getExecutor().interrupt();
+        r.waitForCompletion(b);
     }
 
 }


### PR DESCRIPTION
Subsuming #177. https://github.com/jenkinsci/jenkins-test-harness/pull/198 exposed a mistake in the test.