### PR TITLE
Large `idleMinutes` for `OnceRetentionStrategy`

### DIFF
--- a/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
+++ b/src/main/java/org/jenkinci/plugins/mock_slave/MockCloud.java
@@ -144,7 +144,7 @@ public final class MockCloud extends Cloud {
                 agent.setMode(mode);
                 agent.setNumExecutors(numExecutors);
                 agent.setLabelString(labelString);
-                agent.setRetentionStrategy(oneShot ? new OnceRetentionStrategy(1) : new CloudRetentionStrategy(1));
+                agent.setRetentionStrategy(oneShot ? new OnceRetentionStrategy(5) : new CloudRetentionStrategy(1));
                 future = CompletableFuture.completedFuture(agent);
             } catch (IOException | Descriptor.FormException x) {
                 future = CompletableFuture.failedFuture(x);


### PR DESCRIPTION
Examining a flaky test, I noticed

```
FINE	o.j.p.d.e.OnceRetentionStrategy#check: Disconnecting mock-agent-4
FINE	o.j.p.d.e.OnceRetentionStrategy#done: terminating org.jenkinci.plugins.mock_slave.MockCloud$MockCloudComputer@… idle? true idleStartMilliseconds=…
java.lang.Throwable
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy.done(OnceRetentionStrategy.java:123)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy.check(OnceRetentionStrategy.java:73)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy.check(OnceRetentionStrategy.java:46)
	at hudson.slaves.ComputerRetentionWork$1.run(ComputerRetentionWork.java:71)
	at hudson.model.Queue._withLock(Queue.java:1410)
	at hudson.model.Queue.withLock(Queue.java:1284)
	at hudson.slaves.ComputerRetentionWork.doRun(ComputerRetentionWork.java:62)
```

According to timestamps, it had been idle for almost two minutes, which may be the root cause. Still, it would be better not to delete these agents too aggressively. Under normal conditions they are cleaned up by `OnceRetentionStrategy.taskCompleted`; `check` is called at more or less random times and is intended to be only a fallback to make sure abandoned agents are removed _eventually_.
