### PR TITLE
Option to limit number of concurrent agents per cloud

### DIFF
--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/config.jelly
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/config.jelly
@@ -41,4 +41,7 @@ THE SOFTWARE.
     <f:entry field="inbound" title="Inbound Agents">
         <f:checkbox/>
     </f:entry>
+    <f:entry field="maximum" title="Maximum capacity">
+        <f:number clazz="number" min="0" step="1" default="0"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-maximum.html
+++ b/src/main/resources/org/jenkinci/plugins/mock_slave/MockCloud/help-maximum.html
@@ -1,0 +1,4 @@
+<div>
+    Maximum number of agents to allow at once from this cloud, if positive.
+    By default (zero) there is no limit.
+</div>


### PR DESCRIPTION
Useful for simulating clouds with an “instance cap” or similar concept.